### PR TITLE
Fixed typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,14 +48,14 @@ ReactDOM.render(
 function App() {
   const [appState, setAppState] = useAppState()
   
-  const inclement = () => setAppState({ count: appState.count + 1 })
+  const increment = () => setAppState({ count: appState.count + 1 })
   const decrement = () => setAppState({ count: appState.count - 1 })
 
   return (
     <div>
       <button onClick={increment}>increment</button>
       <button onClick={decrement}>decrement</button>
-      <p>I have {appState.apple.count} apples </p>
+      <p>I have {appState.count} apples </p>
     </div>
   )
 }

--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ function App() {
 
 I wanted **just global version of `setState()`** in some projects.
 So I setup code with `useState()`and `useContext()` then export `useAppState()` hook. 
-Finaly added test, TypeScript supprt with published on npm. 🤗
+Finally added test, TypeScript support with published on npm. 🤗
 
-There is no spefial things against generally kind of `useCotecxt()` hook based grrobal store.
+There is no special things against generally kind of `useContext()` hook based global store.
 
 
 ## 📺 Demo
@@ -183,7 +183,7 @@ ReactDOM.render(
 )
 ```
 
-[React TypeScript Todo Example 2020](https://github.com/laststance/react-typescript-todo-example-2020) using use-app-state so might be good example project.
+[React TypeScript Todo Example 2020](https://github.com/laststance/react-typescript-todo-example-2020) using use-app-state, so it might be a good example project.
 
 
 ## 🥃 Advanced


### PR DESCRIPTION
I found a typo in the readme. It said `inclement` instead of `increment` and also I am pretty sure it is supposed to be `appState.count` and not `appState.apple.count`, so I fixed that as well.